### PR TITLE
Update GMC Yukon XL generations: Add Wikipedia reference and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# Model make
+# GMC Yukon XL
 
+This repository contains signal set configurations for the GMC Yukon XL, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the GMC Yukon XL.
+
+The GMC Yukon XL is the extended-length variant of the GMC Yukon full-size SUV, sharing its platform and major components with the Chevrolet Suburban. Renamed from GMC Suburban to Yukon XL in 2000, it offers increased interior and cargo space compared to the standard-length Yukon while maintaining truck-based capability and towing capacity.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,6 @@
+references:
+  - "https://en.wikipedia.org/wiki/Chevrolet_Suburban"
+
 generations:
   - name: "First Generation (as Suburban)"
     start_year: 1937


### PR DESCRIPTION
- Added references array to generations.yaml with Chevrolet Suburban Wikipedia URL
- Updated README.md with standard template for vehicle documentation
- Verified generational data matches Wikipedia platform timeline (GMT800, GMT900, K2XX, T1XX)
